### PR TITLE
perf: remove graphiteWidth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@
 [![Continuous integration development](https://github.com/fercascue/mono-repo/auth/badge.svg)](https://github.com/fercascue/mono-repo/actions/workflows/CI-Dev.yml)
 
 # mono-repo
-added234567
+added2345678


### PR DESCRIPTION
BREAKING CHANGE: The graphiteWidth option has been removed. The default graphite width of 10mm is always used for performance reasons.
